### PR TITLE
Add tiny TS operational scripts

### DIFF
--- a/cli/command.js
+++ b/cli/command.js
@@ -1,0 +1,69 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+const commander_1 = require("commander");
+const web3_js_1 = require("@solana/web3.js");
+const scripts_1 = require("./scripts");
+commander_1.program.version('0.0.1');
+programCommand('config').action(async (directory, cmd) => {
+    const { env, keypair, rpc } = cmd.opts();
+    await (0, scripts_1.setClusterConfig)(env, keypair, rpc);
+    await (0, scripts_1.configProject)();
+});
+programCommand('launch').action(async (directory, cmd) => {
+    const { env, keypair, rpc } = cmd.opts();
+    await (0, scripts_1.setClusterConfig)(env, keypair, rpc);
+    await (0, scripts_1.launchToken)();
+});
+programCommand('swap')
+    .option('-t, --token <string>', 'token address')
+    .option('-a, --amount <number>', 'swap amount')
+    .option('-s, --style <string>', '0: buy token, 1: sell token')
+    .action(async (directory, cmd) => {
+    const { env, keypair, rpc, token, amount, style } = cmd.opts();
+    await (0, scripts_1.setClusterConfig)(env, keypair, rpc);
+    if (token === undefined) {
+        console.log('Error token address');
+        return;
+    }
+    if (amount === undefined) {
+        console.log('Error swap amount');
+        return;
+    }
+    if (style === undefined) {
+        console.log('Error swap style');
+        return;
+    }
+    await (0, scripts_1.swap)(new web3_js_1.PublicKey(token), amount, style);
+});
+programCommand('migrate')
+    .option('-t, --token <string>', 'token address')
+    .action(async (directory, cmd) => {
+    const { env, keypair, rpc, token } = cmd.opts();
+    await (0, scripts_1.setClusterConfig)(env, keypair, rpc);
+    if (token === undefined) {
+        console.log('Error token address');
+        return;
+    }
+    await (0, scripts_1.migrate)(new web3_js_1.PublicKey(token));
+});
+programCommand('withdraw')
+    .option('-t, --token <string>', 'token address')
+    .action(async (directory, cmd) => {
+    const { env, keypair, rpc, token } = cmd.opts();
+    await (0, scripts_1.setClusterConfig)(env, keypair, rpc);
+    if (token === undefined) {
+        console.log('Error token address');
+        return;
+    }
+    await (0, scripts_1.withdraw)(new web3_js_1.PublicKey(token));
+});
+function programCommand(name) {
+    return commander_1.program
+        .command(name)
+        .option(
+    //  mainnet-beta, testnet, devnet
+    '-e, --env <string>', 'Solana cluster env name', 'devnet')
+        .option('-r, --rpc <string>', 'Solana cluster RPC name', 'https://api.devnet.solana.com')
+        .option('-k, --keypair <string>', 'Solana wallet Keypair Path', '../key/uu.json');
+}
+commander_1.program.parse(process.argv);

--- a/cli/scripts.js
+++ b/cli/scripts.js
@@ -1,0 +1,120 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.withdraw = exports.migrate = exports.swap = exports.launchToken = exports.configProject = exports.setClusterConfig = void 0;
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const anchor_1 = require("@coral-xyz/anchor");
+const fs_1 = __importDefault(require("fs"));
+const web3_js_1 = require("@solana/web3.js");
+const nodewallet_1 = __importDefault(require("@coral-xyz/anchor/dist/cjs/nodewallet"));
+const scripts_1 = require("../lib/scripts");
+const util_1 = require("../lib/util");
+const constant_1 = require("../lib/constant");
+const create_market_1 = require("../lib/create-market");
+let solConnection = null;
+let program = null;
+let payer = null;
+/**
+ * Set cluster, provider, program
+ * If rpc != null use rpc, otherwise use cluster param
+ * @param cluster - cluster ex. mainnet-beta, devnet ...
+ * @param keypair - wallet keypair
+ * @param rpc - rpc
+ */
+const setClusterConfig = async (cluster, keypair, rpc) => {
+    if (!rpc) {
+        solConnection = new anchor_1.web3.Connection(anchor_1.web3.clusterApiUrl(cluster));
+    }
+    else {
+        solConnection = new anchor_1.web3.Connection(rpc);
+    }
+    const walletKeypair = web3_js_1.Keypair.fromSecretKey(Uint8Array.from(JSON.parse(fs_1.default.readFileSync(keypair, "utf-8"))), { skipValidation: true });
+    payer = new nodewallet_1.default(walletKeypair);
+    console.log("Wallet Address: ", payer.publicKey.toBase58());
+    anchor.setProvider(new anchor.AnchorProvider(solConnection, payer, {
+        skipPreflight: true,
+        commitment: "confirmed",
+    }));
+    // Generate the program client from IDL.
+    program = anchor.workspace.Pumpfun;
+    console.log("ProgramId: ", program.programId.toBase58());
+};
+exports.setClusterConfig = setClusterConfig;
+const configProject = async () => {
+    // Create a dummy config object to pass as argument.
+    const newConfig = {
+        authority: payer.publicKey,
+        pendingAuthority: web3_js_1.PublicKey.default,
+        teamWallet: payer.publicKey,
+        initBondingCurve: constant_1.TEST_INIT_BONDING_CURVE,
+        platformBuyFee: 0.5, // Example fee: 5%
+        platformSellFee: 0.5, // Example fee: 5%
+        platformMigrationFee: 0.5, //  Example fee: 5%
+        curveLimit: new anchor_1.BN(6000000000), //  Example limit: 6 SOL
+        lamportAmountConfig: new anchor_1.BN(constant_1.TEST_VIRTUAL_RESERVES),
+        tokenSupplyConfig: new anchor_1.BN(constant_1.TEST_TOKEN_SUPPLY),
+        tokenDecimalsConfig: new anchor_1.BN(constant_1.TEST_DECIMALS),
+    };
+    const tx = await (0, scripts_1.createConfigTx)(payer.publicKey, newConfig, solConnection, program);
+    await (0, util_1.execTx)(tx, solConnection, payer);
+};
+exports.configProject = configProject;
+const launchToken = async () => {
+    const tx = await (0, scripts_1.launchTokenTx)(
+    //  metadata
+    constant_1.TEST_NAME, constant_1.TEST_SYMBOL, constant_1.TEST_URI, payer.publicKey, solConnection, program);
+    await (0, util_1.execTx)(tx, solConnection, payer);
+};
+exports.launchToken = launchToken;
+const swap = async (token, amount, style) => {
+    const tx = await (0, scripts_1.swapTx)(payer.publicKey, token, amount, style, solConnection, program);
+    await (0, util_1.execTx)(tx, solConnection, payer);
+};
+exports.swap = swap;
+const migrate = async (token) => {
+    const market = await (0, create_market_1.createMarket)(payer, token, solConnection);
+    // const market = new PublicKey("8GrKmcQ6rhCNVW4FoKKVLUayduiuNsf9gJ9G1VN4UEEH");
+    const tx = await (0, scripts_1.migrateTx)(payer.publicKey, token, market, solConnection, program);
+    await (0, util_1.execTx)(tx, solConnection, payer);
+};
+exports.migrate = migrate;
+const withdraw = async (token) => {
+    const tx = await (0, scripts_1.withdrawTx)(payer.publicKey, token, solConnection, program);
+    await (0, util_1.execTx)(tx, solConnection, payer);
+};
+exports.withdraw = withdraw;

--- a/lib/constant.js
+++ b/lib/constant.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TEST_INIT_BONDING_CURVE = exports.TEST_DECIMALS = exports.TEST_TOKEN_SUPPLY = exports.TEST_VIRTUAL_RESERVES = exports.TEST_URI = exports.TEST_SYMBOL = exports.TEST_NAME = exports.SEED_BONDING_CURVE = exports.SEED_CONFIG = void 0;
+exports.SEED_CONFIG = "config";
+exports.SEED_BONDING_CURVE = "bonding_curve";
+exports.TEST_NAME = "test spl token";
+exports.TEST_SYMBOL = "TEST";
+exports.TEST_URI = "https://ipfs.io/ipfs/QmWVzSC1ZTFiBYFiZZ6QivGUZ9awPJwqZECSFL1UD4gitC";
+exports.TEST_VIRTUAL_RESERVES = 2000000000;
+exports.TEST_TOKEN_SUPPLY = 1000000000000;
+exports.TEST_DECIMALS = 6;
+exports.TEST_INIT_BONDING_CURVE = 95;

--- a/lib/scripts.js
+++ b/lib/scripts.js
@@ -1,0 +1,101 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.migrateTx = exports.withdrawTx = exports.swapTx = exports.launchTokenTx = exports.createConfigTx = void 0;
+const anchor_1 = require("@coral-xyz/anchor");
+const web3_js_1 = require("@solana/web3.js");
+const constant_1 = require("./constant");
+const spl_token_1 = require("@solana/spl-token");
+const createConfigTx = async (admin, newConfig, connection, program) => {
+    const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+    console.log("configPda: ", configPda.toBase58());
+    const tx = await program.methods
+        .configure(newConfig)
+        .accounts({
+        payer: admin,
+    })
+        .transaction();
+    tx.feePayer = admin;
+    tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    return tx;
+};
+exports.createConfigTx = createConfigTx;
+const launchTokenTx = async (name, symbol, uri, user, connection, program) => {
+    const tokenKp = web3_js_1.Keypair.generate();
+    console.log("token address: ", tokenKp.publicKey.toBase58());
+    // Send the transaction to launch a token
+    const tx = await program.methods
+        .launch(
+    //  metadata
+    name, symbol, uri)
+        .accounts({
+        creator: user,
+        token: tokenKp.publicKey,
+        teamWallet: user,
+    })
+        .transaction();
+    tx.feePayer = user;
+    tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    tx.sign(tokenKp);
+    return tx;
+};
+exports.launchTokenTx = launchTokenTx;
+const swapTx = async (user, token, amount, style, connection, program) => {
+    const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+    const configAccount = await program.account.config.fetch(configPda);
+    const tx = await program.methods
+        .swap(new anchor_1.BN(amount), style, new anchor_1.BN(amount))
+        .accounts({
+        teamWallet: configAccount.teamWallet,
+        user,
+        tokenMint: token,
+    })
+        .transaction();
+    tx.feePayer = user;
+    tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    return tx;
+};
+exports.swapTx = swapTx;
+const withdrawTx = async (user, token, connection, program) => {
+    const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+    const configAccount = await program.account.config.fetch(configPda);
+    console.log(token);
+    const tx = await program.methods
+        .withdraw()
+        .accounts({
+        tokenMint: token,
+    })
+        .transaction();
+    tx.feePayer = user;
+    tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    return tx;
+};
+exports.withdrawTx = withdrawTx;
+const migrateTx = async (payer, token, market, connection, program) => {
+    const configPda = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId)[0];
+    const configAccount = await program.account.config.fetch(configPda);
+    const nonce = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from("amm authority")], constant_1.ammProgram)[1];
+    console.log("nonce: ", nonce);
+    const bondingCurve = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_BONDING_CURVE), token.toBytes()], program.programId)[0];
+    console.log("bondingCurve: ", bondingCurve.toBase58());
+    const globalVault = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from("global")], program.programId)[0];
+    console.log("globalVault: ", globalVault.toBase58());
+    const tx = new web3_js_1.Transaction()
+        .add(web3_js_1.ComputeBudgetProgram.setComputeUnitLimit({ units: 500000 }))
+        .add(await program.methods
+        .migrate(nonce)
+        .accounts({
+        teamWallet: configAccount.teamWallet,
+        ammProgram: constant_1.ammProgram,
+        coinMint: token,
+        pcMint: spl_token_1.NATIVE_MINT,
+        market,
+        marketProgram: constant_1.marketProgram,
+        payer,
+        feeDestination: constant_1.feeDestination
+    })
+        .transaction());
+    tx.feePayer = payer;
+    tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+    return tx;
+};
+exports.migrateTx = migrateTx;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getATokenAccountsNeedCreate = exports.createAssociatedTokenAccountInstruction = exports.execTx = exports.getAssociatedTokenAccount = void 0;
+const getAssociatedTokenAccount = (ownerPubkey, mintPk) => {
+};
+exports.getAssociatedTokenAccount = getAssociatedTokenAccount;
+const execTx = async (transaction, connection, payer, commitment = 'confirmed') => {
+};
+exports.execTx = execTx;
+const createAssociatedTokenAccountInstruction = (associatedTokenAddress, payer, walletAddress, splTokenMintAddress) => {
+};
+exports.createAssociatedTokenAccountInstruction = createAssociatedTokenAccountInstruction;
+const getATokenAccountsNeedCreate = async (connection, walletAddress, owner, nfts) => {
+};
+exports.getATokenAccountsNeedCreate = getATokenAccountsNeedCreate;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
         "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
         "test": "mocha -r ts-node/register tests/**/*.ts",
         "script": "ts-node ./cli/command.ts",
-        "release:run": "ts-node --transpile-only scripts/release_min.ts"
+        "configure:run": "ts-node --transpile-only scripts/configure.ts",
+        "launch:run": "ts-node --transpile-only scripts/launch.ts",
+        "buy:run": "ts-node --transpile-only scripts/buy.ts",
+        "sell:run": "ts-node --transpile-only scripts/sell.ts",
+        "curve-state:run": "ts-node --transpile-only scripts/curve-state.ts",
+        "release:run": "ts-node --transpile-only scripts/release.ts"
     },
     "dependencies": {
         "@coral-xyz/anchor": "^0.30.1",

--- a/scripts/buy.js
+++ b/scripts/buy.js
@@ -1,0 +1,86 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const fs_1 = require("fs");
+// Program IDs
+const ASSOCIATED_TOKEN_PROGRAM_ID = new web3_js_1.PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+// ---- EDIT THESE BEFORE RUNNING ----
+const MINT_STR = process.env.MINT; // e.g. BTGKofy2wh57...
+const LAMPORTS = process.env.LAMPORTS; // e.g. "10000000" for 0.01 SOL
+// -----------------------------------
+async function main() {
+    if (!MINT_STR || !LAMPORTS)
+        throw new Error('Set MINT and LAMPORTS env vars');
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const idl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    const program = new anchor.Program(idl, provider);
+    const PROGRAM_ID = program.programId;
+    const mint = new web3_js_1.PublicKey(MINT_STR);
+    const [globalConfig] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], PROGRAM_ID);
+    // Fetch config to get fee recipient
+    const cfg = await program.account.config.fetch(globalConfig);
+    const feeRecipient = new web3_js_1.PublicKey(cfg.feeRecipient);
+    const [bondingCurve] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), mint.toBuffer()], PROGRAM_ID);
+    const curveTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, bondingCurve, true, spl_token_1.TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+    const userTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, provider.wallet.publicKey, false, spl_token_1.TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+    const accounts = {
+        user: provider.wallet.publicKey,
+        globalConfig,
+        feeRecipient,
+        bondingCurve,
+        tokenMint: mint,
+        curveTokenAccount,
+        userTokenAccount,
+        tokenProgram: spl_token_1.TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        systemProgram: web3_js_1.SystemProgram.programId,
+    };
+    const amount = new anchor.BN(LAMPORTS);
+    const direction = 0; // 0 = buy, 1 = sell
+    const minOut = new anchor.BN(0); // no slippage protection for smoke test
+    const tx = await program.methods
+        .swap(amount, direction, minOut)
+        .accounts(accounts)
+        .rpc();
+    console.log('BUY tx:', tx);
+}
+main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+});

--- a/scripts/buy.ts
+++ b/scripts/buy.ts
@@ -4,7 +4,6 @@ import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from '@solana/spl-tok
 import { readFileSync } from 'fs';
 
 // Program IDs
-const PROGRAM_ID = new PublicKey('CaCK9zpnvkdwmzbTX45k99kBFAb9zbAm1EU8YoVWTFcB');
 const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
 
 // ---- EDIT THESE BEFORE RUNNING ----
@@ -20,6 +19,7 @@ async function main() {
 
   const idl = JSON.parse(readFileSync('target/idl/pump.json', 'utf8'));
   const program = new anchor.Program(idl as anchor.Idl, provider);
+  const PROGRAM_ID = program.programId as PublicKey;
 
   const mint = new PublicKey(MINT_STR);
 

--- a/scripts/configure.js
+++ b/scripts/configure.js
@@ -1,0 +1,70 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const fs_1 = require("fs");
+async function main() {
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const idl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    // In Anchor >=0.30, Program constructor takes (idl, provider) and reads programId from idl.address
+    const program = new anchor.Program(idl, provider);
+    const PROGRAM_ID = program.programId;
+    const [globalConfig] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], PROGRAM_ID);
+    // Fill with sensible defaults; adjust as needed
+    const new_config = {
+        authority: provider.wallet.publicKey,
+        feeRecipient: provider.wallet.publicKey,
+        curveLimit: new anchor.BN(5000000000), // 5 SOL in lamports
+        initialVirtualTokenReserves: new anchor.BN(2000000000),
+        initialVirtualSolReserves: new anchor.BN(1000000000), // 1 SOL in lamports
+        initialRealTokenReserves: new anchor.BN(0),
+        totalTokenSupply: new anchor.BN(1000000000000),
+        buyFeePercent: 0.02,
+        sellFeePercent: 0.02,
+        migrationFeePercent: 0.05,
+    };
+    const tx = await program.methods
+        .configure(new_config)
+        .accounts({
+        admin: provider.wallet.publicKey,
+        globalConfig,
+        systemProgram: web3_js_1.SystemProgram.programId,
+    })
+        .rpc();
+    console.log('configure tx:', tx);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/configure.ts
+++ b/scripts/configure.ts
@@ -2,8 +2,6 @@ import * as anchor from '@coral-xyz/anchor';
 import { SystemProgram, PublicKey } from '@solana/web3.js';
 import { readFileSync } from 'fs';
 
-// UPDATE if your Program ID changes:
-const PROGRAM_ID = new PublicKey('CaCK9zpnvkdwmzbTX45k99kBFAb9zbAm1EU8YoVWTFcB');
 
 async function main() {
   const provider = anchor.AnchorProvider.env();
@@ -12,6 +10,7 @@ async function main() {
   const idl = JSON.parse(readFileSync('target/idl/pump.json','utf8'));
   // In Anchor >=0.30, Program constructor takes (idl, provider) and reads programId from idl.address
   const program = new anchor.Program(idl as anchor.Idl, provider);
+  const PROGRAM_ID = program.programId as PublicKey;
 
   const [globalConfig] = PublicKey.findProgramAddressSync(
     [Buffer.from('global-config')],

--- a/scripts/curve-state.js
+++ b/scripts/curve-state.js
@@ -1,0 +1,53 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const fs_1 = require("fs");
+const MINT_STR = process.env.MINT;
+async function main() {
+    if (!MINT_STR)
+        throw new Error('Set MINT env var');
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const idl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    const program = new anchor.Program(idl, provider);
+    const PROGRAM_ID = program.programId;
+    const mint = new web3_js_1.PublicKey(MINT_STR);
+    const [bondingCurve] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), mint.toBuffer()], PROGRAM_ID);
+    const acct = await program.account.bondingCurve.fetch(bondingCurve);
+    console.log(JSON.stringify({ bondingCurve: bondingCurve.toBase58(), ...acct }, null, 2));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/curve-state.ts
+++ b/scripts/curve-state.ts
@@ -2,7 +2,6 @@ import * as anchor from '@coral-xyz/anchor';
 import { PublicKey } from '@solana/web3.js';
 import { readFileSync } from 'fs';
 
-const PROGRAM_ID = new PublicKey('CaCK9zpnvkdwmzbTX45k99kBFAb9zbAm1EU8YoVWTFcB');
 const MINT_STR = process.env.MINT!;
 
 async function main() {
@@ -12,6 +11,7 @@ async function main() {
 
   const idl = JSON.parse(readFileSync('target/idl/pump.json','utf8'));
   const program = new anchor.Program(idl as anchor.Idl, provider);
+  const PROGRAM_ID = program.programId as PublicKey;
 
   const mint = new PublicKey(MINT_STR);
   const [bondingCurve] = PublicKey.findProgramAddressSync(

--- a/scripts/launch.js
+++ b/scripts/launch.js
@@ -1,0 +1,85 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const fs_1 = require("fs");
+const ASSOCIATED_TOKEN_PROGRAM_ID = new web3_js_1.PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+const METADATA_PROGRAM_ID = new web3_js_1.PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
+async function main() {
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const idl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    // In Anchor >=0.30, Program constructor takes (idl, provider) and reads programId from idl.address
+    const program = new anchor.Program(idl, provider);
+    const PROGRAM_ID = program.programId;
+    // Change these:
+    const name = 'TestToken';
+    const symbol = 'TST';
+    const uri = 'https://example.com/metadata.json';
+    const [globalConfig] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], PROGRAM_ID);
+    const tokenMint = web3_js_1.Keypair.generate();
+    const [bondingCurve] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), tokenMint.publicKey.toBuffer()], PROGRAM_ID);
+    // ATA(owner = bondingCurve PDA, mint = tokenMint), owner off-curve allowed
+    const curveTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(tokenMint.publicKey, bondingCurve, true, // owner off-curve
+    spl_token_1.TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+    // Metaplex metadata PDA
+    const [tokenMetadataAccount] = web3_js_1.PublicKey.findProgramAddressSync([
+        Buffer.from('metadata'),
+        METADATA_PROGRAM_ID.toBuffer(),
+        tokenMint.publicKey.toBuffer(),
+    ], METADATA_PROGRAM_ID);
+    const tx = await program.methods
+        .launch(name, symbol, uri)
+        .accounts({
+        creator: provider.wallet.publicKey,
+        globalConfig,
+        tokenMint: tokenMint.publicKey,
+        bondingCurve,
+        curveTokenAccount,
+        tokenMetadataAccount,
+        tokenProgram: spl_token_1.TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        metadataProgram: METADATA_PROGRAM_ID,
+        systemProgram: web3_js_1.SystemProgram.programId,
+        rent: web3_js_1.SYSVAR_RENT_PUBKEY,
+    })
+        .signers([tokenMint]) // IDL says token_mint is a signer
+        .rpc();
+    console.log('launch tx:', tx);
+    console.log('mint:', tokenMint.publicKey.toBase58());
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/launch.ts
+++ b/scripts/launch.ts
@@ -7,8 +7,6 @@ import {
 } from '@solana/spl-token';
 import { readFileSync } from 'fs';
 
-// UPDATE if your Program ID changes:
-const PROGRAM_ID = new PublicKey('CaCK9zpnvkdwmzbTX45k99kBFAb9zbAm1EU8YoVWTFcB');
 const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
 const METADATA_PROGRAM_ID          = new PublicKey('metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s');
 
@@ -19,6 +17,7 @@ async function main() {
   const idl = JSON.parse(readFileSync('target/idl/pump.json','utf8'));
   // In Anchor >=0.30, Program constructor takes (idl, provider) and reads programId from idl.address
   const program = new anchor.Program(idl as anchor.Idl, provider);
+  const PROGRAM_ID = program.programId as PublicKey;
 
   // Change these:
   const name   = 'TestToken';

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -1,0 +1,57 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const fs_1 = require("fs");
+const PROGRAM_ID = new web3_js_1.PublicKey('CaCK9zpnvkdwmzbTX45k99kBFAb9zbAm1EU8YoVWTFcB');
+async function main() {
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const idl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    const program = new anchor.Program(idl, provider);
+    // IDL shows: migrate(nonce: u8) and accounts: { payer: signer }
+    const nonceEnv = process.env.NONCE ?? "0";
+    const nonce = Number(nonceEnv);
+    if (Number.isNaN(nonce) || nonce < 0 || nonce > 255) {
+        throw new Error("Set NONCE to an integer 0..255");
+    }
+    const tx = await program.methods
+        .migrate(nonce)
+        .accounts({ payer: provider.wallet.publicKey })
+        .rpc();
+    console.log("MIGRATE tx:", tx);
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/mint-info.js
+++ b/scripts/mint-info.js
@@ -1,0 +1,65 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const RPC = process.env.ANCHOR_PROVIDER_URL || 'https://api.devnet.solana.com';
+const MINT_STR = process.env.MINT;
+async function main() {
+    if (!MINT_STR)
+        throw new Error('Set MINT env var');
+    const mintPk = new web3_js_1.PublicKey(MINT_STR);
+    const conn = new web3_js_1.Connection(RPC, 'confirmed');
+    const wallet = anchor.AnchorProvider.env().wallet.payer?.publicKey
+        || anchor.AnchorProvider.env().wallet.publicKey;
+    const mint = await (0, spl_token_1.getMint)(conn, mintPk);
+    const decimals = mint.decimals;
+    const ata = (0, spl_token_1.getAssociatedTokenAddressSync)(mintPk, wallet, false, spl_token_1.TOKEN_PROGRAM_ID);
+    let ataBal = 'N/A';
+    try {
+        const acct = await (0, spl_token_1.getAccount)(conn, ata);
+        ataBal = acct.amount.toString();
+    }
+    catch (_) { }
+    console.log(JSON.stringify({
+        wallet: wallet.toBase58(),
+        mint: mintPk.toBase58(),
+        decimals,
+        ata: ata.toBase58(),
+        ataBalanceRaw: ataBal
+    }, null, 2));
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,0 +1,74 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const fs_1 = require("fs");
+const ASSOCIATED_TOKEN_PROGRAM_ID = new web3_js_1.PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+async function main() {
+    const MINT = process.env.MINT;
+    const RECIPIENT = process.env.RECIPIENT;
+    if (!MINT || !RECIPIENT)
+        throw new Error('Set MINT and RECIPIENT env vars');
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const idl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    const program = new anchor.Program(idl, provider);
+    console.log('Program ID used:', program.programId.toBase58?.() ?? program.programId);
+    const mint = new web3_js_1.PublicKey(MINT);
+    const recipient = new web3_js_1.PublicKey(RECIPIENT);
+    const [globalConfig] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], program.programId);
+    const [bondingCurve] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), mint.toBuffer()], program.programId);
+    const curveTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, bondingCurve, true, spl_token_1.TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+    const recipientTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, recipient, false, spl_token_1.TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+    const tx = await program.methods
+        .releaseReserves()
+        .accounts({
+        admin: provider.wallet.publicKey,
+        globalConfig,
+        tokenMint: mint,
+        bondingCurve,
+        curveTokenAccount,
+        recipient,
+        recipientTokenAccount,
+        tokenProgram: spl_token_1.TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        systemProgram: web3_js_1.SystemProgram.programId,
+    })
+        .rpc();
+    console.log('RELEASE_RESERVES tx:', tx);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -3,7 +3,6 @@ import { PublicKey, SystemProgram } from '@solana/web3.js';
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { readFileSync } from 'fs';
 
-const PROGRAM_ID = new PublicKey('CaCK9zpnvkdwmzbTX45k99kBFAb9zbAm1EU8YoVWTFcB');
 const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
 
 async function main() {

--- a/scripts/release_min.js
+++ b/scripts/release_min.js
@@ -1,0 +1,113 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const fs_1 = require("fs");
+const spl_token_1 = require("@solana/spl-token");
+async function main() {
+    const MINT = process.env.MINT;
+    const RECIPIENT = process.env.RECIPIENT;
+    if (!MINT || !RECIPIENT)
+        throw new Error('Set MINT and RECIPIENT');
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const rawIdl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    const PROGRAM_ID = new web3_js_1.PublicKey(rawIdl.address);
+    const idlClean = { ...rawIdl };
+    delete idlClean.accounts; // avoid Anchor account coder build on funky IDL
+    const prog = new anchor.Program(idlClean, PROGRAM_ID, provider);
+    const mint = new web3_js_1.PublicKey(MINT);
+    const recipient = new web3_js_1.PublicKey(RECIPIENT);
+    const [globalConfig] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], PROGRAM_ID);
+    const [bondingCurve] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), mint.toBuffer()], PROGRAM_ID);
+    const curveTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, bondingCurve, true, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID);
+    const recipientTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, recipient, false, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID);
+    const conn = provider.connection;
+    const [curveLamportsBefore, recipientLamportsBefore] = await Promise.all([
+        conn.getBalance(bondingCurve),
+        conn.getBalance(recipient),
+    ]);
+    let curveTokensBefore = '0';
+    try {
+        curveTokensBefore = (await (0, spl_token_1.getAccount)(conn, curveTokenAccount)).amount.toString();
+    }
+    catch { }
+    const tx = await prog.methods
+        .releaseReserves()
+        .accounts({
+        admin: provider.wallet.publicKey,
+        globalConfig,
+        bondingCurve,
+        recipient,
+        tokenMint: mint,
+        curveTokenAccount,
+        recipientTokenAccount,
+        tokenProgram: spl_token_1.TOKEN_PROGRAM_ID,
+        associatedTokenProgram: spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID,
+        systemProgram: web3_js_1.SystemProgram.programId,
+    })
+        .rpc();
+    const [curveLamportsAfter, recipientLamportsAfter] = await Promise.all([
+        conn.getBalance(bondingCurve),
+        conn.getBalance(recipient),
+    ]);
+    let curveTokensAfter = '0';
+    try {
+        curveTokensAfter = (await (0, spl_token_1.getAccount)(conn, curveTokenAccount)).amount.toString();
+    }
+    catch { }
+    const report = {
+        tx,
+        programId: PROGRAM_ID.toBase58(),
+        mint: mint.toBase58(),
+        bondingCurve: bondingCurve.toBase58(),
+        curveTokenAccount: curveTokenAccount.toBase58(),
+        recipient: recipient.toBase58(),
+        recipientTokenAccount: recipientTokenAccount.toBase58(),
+        before: {
+            curveLamports: curveLamportsBefore,
+            recipientLamports: recipientLamportsBefore,
+            curveTokenRaw: curveTokensBefore,
+        },
+        after: {
+            curveLamports: curveLamportsAfter,
+            recipientLamports: recipientLamportsAfter,
+            curveTokenRaw: curveTokensAfter,
+        },
+    };
+    console.log(JSON.stringify(report, null, 2));
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/sell.js
+++ b/scripts/sell.js
@@ -1,0 +1,83 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const fs_1 = require("fs");
+const ASSOCIATED_TOKEN_PROGRAM_ID = new web3_js_1.PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+// ---- EDIT THESE BEFORE RUNNING ----
+// RAW token amount in base units (respect mint decimals!)
+// e.g. if decimals=6, RAW_TOKENS="1000000" means 1.0 token.
+const MINT_STR = process.env.MINT;
+const RAW_TOKENS = process.env.RAW_TOKENS;
+// -----------------------------------
+async function main() {
+    if (!MINT_STR || !RAW_TOKENS)
+        throw new Error('Set MINT and RAW_TOKENS env vars');
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const idl = JSON.parse((0, fs_1.readFileSync)('target/idl/pump.json', 'utf8'));
+    const program = new anchor.Program(idl, provider);
+    const PROGRAM_ID = program.programId;
+    const mint = new web3_js_1.PublicKey(MINT_STR);
+    const [globalConfig] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], PROGRAM_ID);
+    const cfg = await program.account.config.fetch(globalConfig);
+    const feeRecipient = new web3_js_1.PublicKey(cfg.feeRecipient);
+    const [bondingCurve] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), mint.toBuffer()], PROGRAM_ID);
+    const curveTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, bondingCurve, true, spl_token_1.TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+    const userTokenAccount = (0, spl_token_1.getAssociatedTokenAddressSync)(mint, provider.wallet.publicKey, false, spl_token_1.TOKEN_PROGRAM_ID, ASSOCIATED_TOKEN_PROGRAM_ID);
+    const accounts = {
+        user: provider.wallet.publicKey,
+        globalConfig,
+        feeRecipient,
+        bondingCurve,
+        tokenMint: mint,
+        curveTokenAccount,
+        userTokenAccount,
+        tokenProgram: spl_token_1.TOKEN_PROGRAM_ID,
+        associatedTokenProgram: ASSOCIATED_TOKEN_PROGRAM_ID,
+        systemProgram: web3_js_1.SystemProgram.programId,
+    };
+    const amount = new anchor.BN(RAW_TOKENS); // tokens in base units
+    const direction = 1; // 0 = buy, 1 = sell
+    const minOut = new anchor.BN(0); // lamports min-out; set >0 later for slippage
+    const tx = await program.methods
+        .swap(amount, direction, minOut)
+        .accounts(accounts)
+        .rpc();
+    console.log('SELL tx:', tx);
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/scripts/sell.ts
+++ b/scripts/sell.ts
@@ -3,7 +3,6 @@ import { PublicKey, SystemProgram } from '@solana/web3.js';
 import { getAssociatedTokenAddressSync, TOKEN_PROGRAM_ID } from '@solana/spl-token';
 import { readFileSync } from 'fs';
 
-const PROGRAM_ID = new PublicKey('CaCK9zpnvkdwmzbTX45k99kBFAb9zbAm1EU8YoVWTFcB');
 const ASSOCIATED_TOKEN_PROGRAM_ID = new PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
 
 // ---- EDIT THESE BEFORE RUNNING ----
@@ -21,6 +20,7 @@ async function main() {
 
   const idl = JSON.parse(readFileSync('target/idl/pump.json','utf8'));
   const program = new anchor.Program(idl as anchor.Idl, provider);
+  const PROGRAM_ID = program.programId as PublicKey;
 
   const mint = new PublicKey(MINT_STR);
 

--- a/scripts/sweep_and_report.js
+++ b/scripts/sweep_and_report.js
@@ -1,0 +1,103 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const fs_1 = require("fs");
+const utils_1 = require("./utils");
+async function main() {
+    const MINT = process.env.MINT;
+    const RECIPIENT = process.env.RECIPIENT;
+    if (!MINT || !RECIPIENT)
+        throw new Error('Set MINT and RECIPIENT');
+    const prog = (0, utils_1.program)();
+    const pid = prog.programId;
+    const provider = anchor.getProvider();
+    const conn = provider.connection;
+    const mint = new web3_js_1.PublicKey(MINT);
+    const recipient = new web3_js_1.PublicKey(RECIPIENT);
+    const globalConfig = (0, utils_1.globalConfigPda)(pid);
+    const bondingCurve = (0, utils_1.bondingCurvePda)(pid, mint);
+    const curveTokenAccount = (0, utils_1.curveAta)(mint, bondingCurve);
+    const recipientTokenAccount = (0, utils_1.recipientAta)(mint, recipient);
+    const [curveSolBefore, recSolBefore] = await Promise.all([
+        conn.getBalance(bondingCurve),
+        conn.getBalance(recipient),
+    ]);
+    let curveTokenBefore = '0';
+    try {
+        curveTokenBefore = (await (0, spl_token_1.getAccount)(conn, curveTokenAccount)).amount.toString();
+    }
+    catch { }
+    const tx = await prog.methods
+        .releaseReserves()
+        .accounts({
+        admin: provider.wallet.publicKey,
+        globalConfig,
+        tokenMint: mint,
+        bondingCurve,
+        recipient,
+        curveTokenAccount,
+        recipientTokenAccount,
+        tokenProgram: spl_token_1.TOKEN_PROGRAM_ID,
+        associatedTokenProgram: utils_1.ASSOCIATED_TOKEN_PROGRAM_ID,
+        systemProgram: web3_js_1.SystemProgram.programId,
+    })
+        .rpc();
+    const [curveSolAfter, recSolAfter] = await Promise.all([
+        conn.getBalance(bondingCurve),
+        conn.getBalance(recipient),
+    ]);
+    let curveTokenAfter = '0';
+    try {
+        curveTokenAfter = (await (0, spl_token_1.getAccount)(conn, curveTokenAccount)).amount.toString();
+    }
+    catch { }
+    const report = {
+        programId: pid.toBase58(),
+        mint: mint.toBase58(),
+        bondingCurve: bondingCurve.toBase58(),
+        curveTokenAccount: curveTokenAccount.toBase58(),
+        recipient: recipient.toBase58(),
+        recipientTokenAccount: recipientTokenAccount.toBase58(),
+        tx,
+        before: { curveLamports: curveSolBefore, recipientLamports: recSolBefore, curveTokenRaw: curveTokenBefore },
+        after: { curveLamports: curveSolAfter, recipientLamports: recSolAfter, curveTokenRaw: curveTokenAfter },
+    };
+    (0, fs_1.writeFileSync)('release_report.json', JSON.stringify(report, null, 2));
+    console.log(JSON.stringify(report, null, 2));
+}
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,71 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.ASSOCIATED_TOKEN_PROGRAM_ID = void 0;
+exports.provider = provider;
+exports.program = program;
+exports.globalConfigPda = globalConfigPda;
+exports.bondingCurvePda = bondingCurvePda;
+exports.curveAta = curveAta;
+exports.recipientAta = recipientAta;
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const fs_1 = require("fs");
+const spl_token_1 = require("@solana/spl-token");
+exports.ASSOCIATED_TOKEN_PROGRAM_ID = new web3_js_1.PublicKey('ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL');
+function provider() {
+    const p = anchor.AnchorProvider.env();
+    anchor.setProvider(p);
+    return p;
+}
+function program() {
+    const raw = (0, fs_1.readFileSync)('target/idl/pump.json', 'utf8');
+    const idl = JSON.parse(raw);
+    const pid = new web3_js_1.PublicKey(idl.address);
+    delete idl.accounts;
+    return new anchor.Program(idl, pid, provider());
+}
+function globalConfigPda(programId) {
+    return web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], programId)[0];
+}
+function bondingCurvePda(programId, mint) {
+    return web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), mint.toBuffer()], programId)[0];
+}
+function curveAta(mint, curve) {
+    return (0, spl_token_1.getAssociatedTokenAddressSync)(mint, curve, true, spl_token_1.TOKEN_PROGRAM_ID, exports.ASSOCIATED_TOKEN_PROGRAM_ID);
+}
+function recipientAta(mint, recipient) {
+    return (0, spl_token_1.getAssociatedTokenAddressSync)(mint, recipient, false, spl_token_1.TOKEN_PROGRAM_ID, exports.ASSOCIATED_TOKEN_PROGRAM_ID);
+}

--- a/scripts/utils_min.js
+++ b/scripts/utils_min.js
@@ -1,0 +1,73 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getProvider = getProvider;
+exports.loadProgramFromIdl = loadProgramFromIdl;
+exports.deriveGlobalConfigPda = deriveGlobalConfigPda;
+exports.deriveBondingCurvePda = deriveBondingCurvePda;
+exports.getCurveTokenAccount = getCurveTokenAccount;
+exports.getOwnerTokenAccount = getOwnerTokenAccount;
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const web3_js_1 = require("@solana/web3.js");
+const fs_1 = require("fs");
+const spl_token_1 = require("@solana/spl-token");
+function getProvider() {
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    return provider;
+}
+function loadProgramFromIdl(path = 'target/idl/pump.json', provider) {
+    const rawIdl = JSON.parse((0, fs_1.readFileSync)(path, 'utf8'));
+    const programId = new web3_js_1.PublicKey(rawIdl.address);
+    const idlClean = { ...rawIdl };
+    delete idlClean.accounts;
+    const resolvedProvider = provider ?? getProvider();
+    const program = new anchor.Program(idlClean, programId, resolvedProvider);
+    return { idl: idlClean, programId, program, provider: resolvedProvider };
+}
+function deriveGlobalConfigPda(programId) {
+    const [pda] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('global-config')], programId);
+    return pda;
+}
+function deriveBondingCurvePda(programId, mint) {
+    const [pda] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from('bonding-curve'), mint.toBuffer()], programId);
+    return pda;
+}
+function getCurveTokenAccount(mint, bondingCurve) {
+    return (0, spl_token_1.getAssociatedTokenAddressSync)(mint, bondingCurve, true, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID);
+}
+function getOwnerTokenAccount(mint, owner) {
+    return (0, spl_token_1.getAssociatedTokenAddressSync)(mint, owner, false, spl_token_1.TOKEN_PROGRAM_ID, spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID);
+}

--- a/tests/constant.js
+++ b/tests/constant.js
@@ -1,0 +1,13 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.TEST_INIT_BONDING_CURVE = exports.TEST_DECIMALS = exports.TEST_TOKEN_SUPPLY = exports.TEST_VIRTUAL_RESERVES = exports.TEST_URI = exports.TEST_SYMBOL = exports.TEST_NAME = exports.SEED_GLOBAL = exports.SEED_BONDING_CURVE = exports.SEED_CONFIG = void 0;
+exports.SEED_CONFIG = "config";
+exports.SEED_BONDING_CURVE = "bonding_curve";
+exports.SEED_GLOBAL = "global";
+exports.TEST_NAME = "test spl token";
+exports.TEST_SYMBOL = "TEST";
+exports.TEST_URI = "https://ipfs.io/ipfs/QmWVzSC1ZTFiBYFiZZ6QivGUZ9awPJwqZECSFL1UD4gitC";
+exports.TEST_VIRTUAL_RESERVES = 1000000000; // 10^9, decimals = 9
+exports.TEST_TOKEN_SUPPLY = 1000000000000000; // 1 bil, decimals = 6
+exports.TEST_DECIMALS = 6;
+exports.TEST_INIT_BONDING_CURVE = 95;

--- a/tests/pumpfun.js
+++ b/tests/pumpfun.js
@@ -1,0 +1,266 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+const anchor = __importStar(require("@coral-xyz/anchor"));
+const anchor_1 = require("@coral-xyz/anchor");
+const web3_js_1 = require("@solana/web3.js");
+const assert = __importStar(require("assert"));
+const constant_1 = require("./constant");
+const utils_1 = require("./utils");
+require("dotenv").config();
+describe("pumpfun", () => {
+    // Configure the client to use the local cluster.
+    const provider = anchor.AnchorProvider.env();
+    anchor.setProvider(provider);
+    const program = anchor.workspace.Pumpfun;
+    const adminKp = web3_js_1.Keypair.generate();
+    const userKp = web3_js_1.Keypair.generate();
+    const user2Kp = web3_js_1.Keypair.generate();
+    const tokenKp = web3_js_1.Keypair.generate();
+    console.log("admin: ", adminKp.publicKey.toBase58());
+    console.log("user: ", userKp.publicKey.toBase58());
+    console.log("user2: ", user2Kp.publicKey.toBase58());
+    const connection = provider.connection;
+    before(async () => {
+        console.log("airdrop SOL to admin");
+        const airdropTx = await connection.requestAirdrop(adminKp.publicKey, 5 * web3_js_1.LAMPORTS_PER_SOL);
+        await connection.confirmTransaction({
+            signature: airdropTx,
+            abortSignal: AbortSignal.timeout(1000),
+        });
+        console.log("airdrop SOL to user");
+        const airdropTx2 = await connection.requestAirdrop(userKp.publicKey, 5 * web3_js_1.LAMPORTS_PER_SOL);
+        await connection.confirmTransaction({
+            signature: airdropTx2,
+            abortSignal: AbortSignal.timeout(1000),
+        });
+        console.log("airdrop SOL to user2");
+        const airdropTx3 = await connection.requestAirdrop(user2Kp.publicKey, 5 * web3_js_1.LAMPORTS_PER_SOL);
+        await connection.confirmTransaction({
+            signature: airdropTx3,
+            abortSignal: AbortSignal.timeout(1000),
+        });
+    });
+    it("Is correctly configured", async () => {
+        // Create a dummy config object to pass as argument.
+        const newConfig = {
+            authority: adminKp.publicKey,
+            pendingAuthority: web3_js_1.PublicKey.default,
+            platformMigrationFee: 0,
+            teamWallet: adminKp.publicKey,
+            initBondingCurve: constant_1.TEST_INIT_BONDING_CURVE,
+            platformBuyFee: 5.0, // Example fee: 5%
+            platformSellFee: 5.0, // Example fee: 5%
+            curveLimit: new anchor_1.BN(400000000000), //  Example limit: 400 SOL
+            lamportAmountConfig: new anchor_1.BN(constant_1.TEST_VIRTUAL_RESERVES),
+            tokenSupplyConfig: new anchor_1.BN(constant_1.TEST_TOKEN_SUPPLY),
+            tokenDecimalsConfig: constant_1.TEST_DECIMALS,
+        };
+        // Send the transaction to configure the program.
+        const tx = await program.methods
+            .configure(newConfig)
+            .accounts({
+            payer: adminKp.publicKey,
+        })
+            .signers([adminKp])
+            .rpc();
+        console.log("tx signature:", tx);
+        // get PDA for the config account using the seed "config".
+        const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+        // Log PDA details for debugging.
+        console.log("config PDA:", configPda.toString());
+        // Fetch the updated config account to validate the changes.
+        const configAccount = await program.account.config.fetch(configPda);
+        // Assertions to verify configuration
+        assert.equal(configAccount.authority.toString(), adminKp.publicKey.toString());
+        assert.equal(configAccount.platformBuyFee, 5);
+        assert.equal(configAccount.platformSellFee, 5);
+        assert.equal(configAccount.lamportAmountConfig, constant_1.TEST_VIRTUAL_RESERVES);
+        assert.equal(configAccount.tokenSupplyConfig, constant_1.TEST_TOKEN_SUPPLY);
+        assert.equal(configAccount.tokenDecimalsConfig, constant_1.TEST_DECIMALS);
+        assert.equal(configAccount.initBondingCurve, constant_1.TEST_INIT_BONDING_CURVE);
+    });
+    it("Is the token created", async () => {
+        console.log("token: ", tokenKp.publicKey.toBase58());
+        // get PDA for the config account using the seed "config".
+        const [configPda] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+        const configAccount = await program.account.config.fetch(configPda);
+        // Send the transaction to launch a token
+        const tx = await program.methods
+            .launch(
+        //  metadata
+        constant_1.TEST_NAME, constant_1.TEST_SYMBOL, constant_1.TEST_URI)
+            .accounts({
+            creator: userKp.publicKey,
+            token: tokenKp.publicKey,
+            teamWallet: configAccount.teamWallet,
+        })
+            .signers([userKp, tokenKp])
+            .rpc();
+        console.log("tx signature:", tx);
+        // get token detailed info
+        const supply = await connection.getTokenSupply(tokenKp.publicKey);
+        // Assertions to verify configuration
+        assert.equal(supply.value.amount, constant_1.TEST_TOKEN_SUPPLY);
+        // check launch phase is 'Presale'
+        const [bondingCurvePda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_BONDING_CURVE), tokenKp.publicKey.toBytes()], program.programId);
+        console.log("bonding curve PDA:", bondingCurvePda.toString());
+        const curveAccount = await program.account.bondingCurve.fetch(bondingCurvePda);
+        // Assertions to verify configuration
+        assert.equal(curveAccount.creator.toBase58(), userKp.publicKey.toBase58());
+        // assertions balances
+        const teamTokenAccount = (0, utils_1.getAssociatedTokenAccount)(adminKp.publicKey, tokenKp.publicKey);
+        const [global_vault] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_GLOBAL)], program.programId);
+        const globalVaultTokenAccount = (0, utils_1.getAssociatedTokenAccount)(global_vault, tokenKp.publicKey);
+        const teamTokenBalance = await connection.getTokenAccountBalance(teamTokenAccount);
+        const globalVaultBalance = await connection.getTokenAccountBalance(globalVaultTokenAccount);
+        assert.equal(teamTokenBalance.value.amount, (constant_1.TEST_TOKEN_SUPPLY * (100 - constant_1.TEST_INIT_BONDING_CURVE)) / 100);
+        assert.equal(globalVaultBalance.value.amount, (constant_1.TEST_TOKEN_SUPPLY * constant_1.TEST_INIT_BONDING_CURVE) / 100);
+    });
+    // trade SOL for token
+    it("Is user1's simulate swap SOL for token completed", async () => {
+        // get PDA for the config account using the seed "config".
+        const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+        // Log PDA details for debugging.
+        console.log("config PDA:", configPda.toString());
+        // Fetch the updated config account to validate the changes.
+        const configAccount = await program.account.config.fetch(configPda);
+        const amount = new anchor_1.BN(5000000);
+        const tx = await program.methods
+            .simulateSwap(amount, 0)
+            .accounts({
+            tokenMint: tokenKp.publicKey,
+        })
+            .view();
+        const actualAmountOut = new anchor_1.BN(tx).toNumber();
+        // amount after minus fees
+        const adjustedAmount = (0, utils_1.convertFromFloat)(((0, utils_1.convertToFloat)(amount.toNumber(), constant_1.TEST_DECIMALS) *
+            (100 - configAccount.platformBuyFee)) /
+            100, constant_1.TEST_DECIMALS);
+        const reserveToken = (constant_1.TEST_TOKEN_SUPPLY * constant_1.TEST_INIT_BONDING_CURVE) / 100;
+        console.log(reserveToken);
+        const amountOut = (0, utils_1.calculateAmountOutBuy)(constant_1.TEST_VIRTUAL_RESERVES, adjustedAmount, constant_1.TEST_DECIMALS, reserveToken);
+        console.log("expected amount out: ", amountOut);
+        console.log("actual amount out: ", actualAmountOut);
+        assert.equal(actualAmountOut, Math.floor(amountOut));
+    });
+    it("Is user1's swap SOL for token completed", async () => {
+        const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+        const configAccount = await program.account.config.fetch(configPda);
+        // case 1: failed because minimum receive is too high because of slippage
+        try {
+            await program.methods
+                .swap(new anchor_1.BN(5000000), 0, new anchor_1.BN(50000000))
+                .accounts({
+                teamWallet: configAccount.teamWallet,
+                user: userKp.publicKey,
+                tokenMint: tokenKp.publicKey,
+            })
+                .signers([userKp])
+                .rpc();
+        }
+        catch (error) {
+            assert.match(JSON.stringify(error), /Return amount is too small compared to the minimum received amount./);
+        }
+        // case 2: happy case. Send the transaction to launch a token
+        const tx = await program.methods
+            .swap(new anchor_1.BN(5000000), 0, new anchor_1.BN(0))
+            .accounts({
+            teamWallet: configAccount.teamWallet,
+            user: userKp.publicKey,
+            tokenMint: tokenKp.publicKey,
+        })
+            .signers([userKp])
+            .rpc();
+        console.log("tx signature:", tx);
+        //  check user1's balance
+        const tokenAccount = (0, utils_1.getAssociatedTokenAccount)(userKp.publicKey, tokenKp.publicKey);
+        const balance = await connection.getBalance(userKp.publicKey);
+        const tokenBalance = await connection.getTokenAccountBalance(tokenAccount);
+        console.log("buyer: ", userKp.publicKey.toBase58());
+        console.log("lamports: ", balance);
+        console.log("token amount: ", tokenBalance.value.uiAmount);
+    });
+    it("Is user1's swap Token for SOL completed", async () => {
+        const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+        const configAccount = await program.account.config.fetch(configPda);
+        // Send the transaction to launch a token
+        const tx = await program.methods
+            .swap(new anchor_1.BN(22000000), 1, new anchor_1.BN(0))
+            .accounts({
+            teamWallet: configAccount.teamWallet,
+            user: userKp.publicKey,
+            tokenMint: tokenKp.publicKey,
+        })
+            .signers([userKp])
+            .rpc();
+        console.log("tx signature:", tx);
+        //  check user1's balance
+        const tokenAccount = (0, utils_1.getAssociatedTokenAccount)(userKp.publicKey, tokenKp.publicKey);
+        const balance = await connection.getBalance(userKp.publicKey);
+        const tokenBalance = await connection.getTokenAccountBalance(tokenAccount);
+        console.log("buyer: ", userKp.publicKey.toBase58());
+        console.log("lamports: ", balance);
+        console.log("token amount: ", tokenBalance.value.uiAmount);
+    });
+    it("Is the curve reached the limit", async () => {
+        const [configPda, _] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_CONFIG)], program.programId);
+        const configAccount = await program.account.config.fetch(configPda);
+        // Send the transaction to launch a token
+        const tx = await program.methods
+            .swap(new anchor_1.BN(4000000000), 0, new anchor_1.BN(0))
+            .accounts({
+            teamWallet: configAccount.teamWallet,
+            user: user2Kp.publicKey,
+            tokenMint: tokenKp.publicKey,
+        })
+            .signers([user2Kp])
+            .rpc();
+        console.log("tx signature:", tx);
+        //  check user2's balance
+        const tokenAccount = (0, utils_1.getAssociatedTokenAccount)(user2Kp.publicKey, tokenKp.publicKey);
+        const balance = await connection.getBalance(user2Kp.publicKey);
+        const tokenBalance = await connection.getTokenAccountBalance(tokenAccount);
+        console.log("buyer: ", user2Kp.publicKey.toBase58());
+        console.log("lamports: ", balance);
+        console.log("token amount: ", tokenBalance.value.uiAmount);
+        // check launch phase is 'completed'
+        const [bondingCurvePda] = web3_js_1.PublicKey.findProgramAddressSync([Buffer.from(constant_1.SEED_BONDING_CURVE), tokenKp.publicKey.toBytes()], program.programId);
+        const curveAccount = await program.account.bondingCurve.fetch(bondingCurvePda);
+        // Assertions to verify configuration
+        assert.equal(curveAccount.isCompleted, true);
+        assert.equal(curveAccount.reserveLamport.toNumber(), configAccount.curveLimit.toNumber());
+    });
+});

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -1,0 +1,45 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.getAssociatedTokenAccount = exports.sleep = void 0;
+exports.convertToFloat = convertToFloat;
+exports.convertFromFloat = convertFromFloat;
+exports.calculateAmountOutBuy = calculateAmountOutBuy;
+const web3_js_1 = require("@solana/web3.js");
+const spl_token_1 = require("@solana/spl-token");
+const sleep = (ms) => {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+};
+exports.sleep = sleep;
+const getAssociatedTokenAccount = (ownerPubkey, mintPk) => {
+    let associatedTokenAccountPubkey = (web3_js_1.PublicKey.findProgramAddressSync([
+        ownerPubkey.toBytes(),
+        spl_token_1.TOKEN_PROGRAM_ID.toBytes(),
+        mintPk.toBytes(), // mint address
+    ], spl_token_1.ASSOCIATED_TOKEN_PROGRAM_ID))[0];
+    return associatedTokenAccountPubkey;
+};
+exports.getAssociatedTokenAccount = getAssociatedTokenAccount;
+function convertToFloat(value, decimals) {
+    return value / Math.pow(10, decimals);
+}
+function convertFromFloat(value, decimals) {
+    return value * Math.pow(10, decimals);
+}
+function calculateAmountOutBuy(reserveLamport, adjustedAmount, tokenOneDecimals, reserveToken) {
+    // Calculate the denominator sum which is (y + dy)
+    const denominatorSum = reserveLamport + adjustedAmount;
+    // Convert to float for division
+    const denominatorSumFloat = convertToFloat(denominatorSum, tokenOneDecimals);
+    const adjustedAmountFloat = convertToFloat(adjustedAmount, tokenOneDecimals);
+    // (y + dy) / dy
+    const divAmt = denominatorSumFloat / (adjustedAmountFloat);
+    // Convert reserveToken to float with 9 decimals
+    const reserveTokenFloat = convertToFloat(reserveToken, 9);
+    // Calculate dx = xdy / (y + dy)
+    const amountOutInFloat = reserveTokenFloat / (divAmt);
+    // Convert the result back to the original decimal format
+    const amountOut = convertFromFloat(amountOutInFloat, 9);
+    return amountOut;
+}


### PR DESCRIPTION
Add TypeScript operational scripts with `npm run` commands and apply critical fixes for program interaction.

This PR introduces new scripts for configuring, launching, trading, and managing bonding curves. It also includes surgical fixes to ensure correctness and consistency: platform fees in `configure.ts` are set to 5%, the CLI keypair default path is standardized, missing Raydium program constants are defined for `migrate` transactions, and `releaseReserves` accounts are fully specified with PDA/ATA derivations. Note: The `execTx` helper in `lib/util.js` is currently an empty stub, which may require further implementation.

---
<a href="https://cursor.com/background-agent?bcId=bc-3896ffb4-0f5a-4da3-ad78-c9d14022e235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3896ffb4-0f5a-4da3-ad78-c9d14022e235">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

