### PR TITLE
Enforce safety rails in smart contract

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## Enforce pause/completion guards + tests
+
+- Brief summary of changes and rationale
+- Guard coverage table copied from `SECURITY_NOTES.md`
+- Instructions to run tests locally
+
+### Running locally
+
+- Requires Anchor toolchain and Solana local validator.
+- Build: `anchor build`
+- Test (TS): `anchor test`
+- Test (Rust, optional): `cargo test -p pump`

--- a/README.md
+++ b/README.md
@@ -155,3 +155,10 @@ Migrate token to raydium once the curve is completed:
 yarn script migrate -t <TOKEN_MINT>
 # <TOKEN_MINT>: mint address of the token to be launched on the raydium
 ```
+
+## Running locally
+
+- Ensure Anchor CLI and a Solana validator are installed
+- Build: `anchor build`
+- Tests (TypeScript): `anchor test`
+- Optional Rust tests: `cargo test -p pump`

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,0 +1,19 @@
+# Security Notes
+
+Instruction guard coverage summary:
+
+- **configure**: admin-only (authority must equal `global_config.authority`, except first init when default). Does not use paused/completed flags to allow configuration; behavior unchanged aside from explicit admin check helper.
+- **launch**: blocked when `paused` or `is_completed` on `Config` is true.
+- **swap**: blocked when `paused` or `is_completed` on `Config` is true. Also blocked when per-curve `bonding_curve.is_completed` is true.
+- **migrate**: admin-only; blocked when `paused` or `is_completed` on `Config` is true.
+- **release_reserves**: admin-only; blocked when `paused` is true; requires `bonding_curve.is_completed`.
+
+Table
+
+| Instruction       | Admin required | Blocks when paused | Blocks when is_completed |
+|-------------------|----------------|--------------------|---------------------------|
+| configure         | Yes (except init) | No                 | No                        |
+| launch            | No             | Yes                | Yes                       |
+| swap              | No             | Yes                | Yes                       |
+| migrate           | Yes            | Yes                | Yes                       |
+| release_reserves  | Yes            | Yes                | No (but curve must be completed) |

--- a/SECURITY_NOTES.md
+++ b/SECURITY_NOTES.md
@@ -1,5 +1,7 @@
 # Security Notes
 
+This document inventories on-chain instructions and the guard rails applied. It summarizes admin requirements and whether instructions block when `paused` or `is_completed` on `Config`.
+
 Instruction guard coverage summary:
 
 - **configure**: admin-only (authority must equal `global_config.authority`, except first init when default). Does not use paused/completed flags to allow configuration; behavior unchanged aside from explicit admin check helper.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "scripts": {
         "lint:fix": "prettier */*.js \"*/**/*{.js,.ts}\" -w",
         "lint": "prettier */*.js \"*/**/*{.js,.ts}\" --check",
-        "test": "mocha -r ts-node/register tests/**/*.ts",
+        "test": "ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.ts",
         "script": "ts-node ./cli/command.ts",
         "release:run": "ts-node --transpile-only scripts/release_min.ts"
     },

--- a/programs/pump/src/errors.rs
+++ b/programs/pump/src/errors.rs
@@ -19,4 +19,10 @@ pub enum PumpError {
 
     #[msg("Curve is already completed")]
     CurveAlreadyCompleted,
+
+    #[msg("Program is paused")]
+    ProgramPaused,
+
+    #[msg("Program is completed")]
+    ProgramCompleted,
 }

--- a/programs/pump/src/instructions/launch.rs
+++ b/programs/pump/src/instructions/launch.rs
@@ -1,6 +1,7 @@
 use crate::{
     consts::TOKEN_DECIMAL,
     states::{BondingCurve, Config},
+    utils::{ensure_not_completed, ensure_not_paused},
 };
 use anchor_lang::{prelude::*, solana_program::sysvar::SysvarId, system_program};
 use anchor_spl::{
@@ -73,7 +74,10 @@ impl<'info> Launch<'info> {
         uri: String,
 
         bump_config: u8,
-    ) -> Result<()> {
+    ) -> Result<()> { 
+        // global guards
+        ensure_not_paused(&self.global_config.as_ref())?;
+        ensure_not_completed(&self.global_config.as_ref())?;
         let bonding_curve = &mut self.bonding_curve;
         let global_config = &self.global_config;
 

--- a/programs/pump/src/instructions/migrate.rs
+++ b/programs/pump/src/instructions/migrate.rs
@@ -1,13 +1,22 @@
 use anchor_lang::prelude::*;
+use crate::{states::Config, utils::{ensure_admin, ensure_not_completed, ensure_not_paused}};
 
 #[derive(Accounts)]
 pub struct Migrate<'info> {
     #[account(mut)]
     payer: Signer<'info>,
+
+    #[account(seeds = [Config::SEED_PREFIX.as_bytes()], bump)]
+    global_config: Account<'info, Config>,
 }
 
 impl<'info> Migrate<'info> {
     pub fn process(&mut self, _nonce: u8) -> Result<()> {
+        // Only admin may migrate and only when not paused and not completed
+        ensure_not_paused(&self.global_config.as_ref())?;
+        ensure_not_completed(&self.global_config.as_ref())?;
+        ensure_admin(&self.global_config.as_ref(), &self.payer.key())?;
+
         ////////////////////    DM if you want full implementation    ////////////////////
         // telegram - https://t.me/microgift88
         // discord - https://discord.com/users/1074514238325927956

--- a/programs/pump/src/instructions/release_reserves.rs
+++ b/programs/pump/src/instructions/release_reserves.rs
@@ -1,4 +1,4 @@
-use crate::states::{BondingCurve, Config};
+use crate::{states::{BondingCurve, Config}, utils::{ensure_admin, ensure_not_paused}};
 use anchor_lang::{prelude::*, system_program};
 use anchor_lang::solana_program::sysvar::rent::Rent;
 use anchor_spl::associated_token::{self, AssociatedToken};
@@ -64,6 +64,9 @@ pub enum ReleaseReservesError {
 
 impl<'info> ReleaseReserves<'info> {
     pub fn process(&mut self, bump_bonding_curve: u8) -> Result<()> {
+        // global pause guard and admin check
+        ensure_not_paused(&self.global_config.as_ref())?;
+        ensure_admin(&self.global_config.as_ref(), &self.admin.key())?;
         // ensure curve completed
         require!(self.bonding_curve.is_completed, ReleaseReservesError::CurveNotCompleted);
 

--- a/programs/pump/src/instructions/swap.rs
+++ b/programs/pump/src/instructions/swap.rs
@@ -1,5 +1,5 @@
 use crate::{
-    errors::PumpError, states::{BondingCurve, Config}
+    errors::PumpError, states::{BondingCurve, Config}, utils::{ensure_not_completed, ensure_not_paused}
 };
 use anchor_lang::{prelude::*, system_program};
 use anchor_spl::{
@@ -62,6 +62,9 @@ impl<'info> Swap<'info> {
 
         bump_bonding_curve: u8,
     ) -> Result<()> {
+        // global guards
+        ensure_not_paused(&self.global_config.as_ref())?;
+        ensure_not_completed(&self.global_config.as_ref())?;
         let bonding_curve = &mut self.bonding_curve;
 
         //  check curve is not completed

--- a/programs/pump/src/lib.rs
+++ b/programs/pump/src/lib.rs
@@ -16,11 +16,13 @@ pub mod pump {
 
     //  called by admin to set global config
     //  need to check the signer is authority
+    //  global guards: enforced in each handler as appropriate
     pub fn configure(ctx: Context<Configure>, new_config: states::Config) -> Result<()> {
         ctx.accounts.process(new_config)
     }
 
     //  called by a creator to launch a token on the platform
+    //  global guards: paused/completed enforced
     pub fn launch<'info>(
         ctx: Context<'_, '_, '_, 'info, Launch<'info>>,
 
@@ -34,6 +36,7 @@ pub mod pump {
     }
 
     //  called by a user to swap token/sol
+    //  global guards: paused/completed enforced
     pub fn swap<'info>(
         ctx: Context<'_, '_, '_, 'info, Swap<'info>>,
         amount: u64,
@@ -49,6 +52,7 @@ pub mod pump {
     // discord - https://discord.com/users/1074514238325927956
 
     //  migrate the token to raydium once a curve reaches the limit
+    //  global guards: paused/completed and admin enforced
     pub fn migrate<'info>(
         ctx: Context<'_, '_, '_, 'info, Migrate<'info>>,
         nonce: u8,
@@ -57,6 +61,7 @@ pub mod pump {
     }
 
     // release reserves from completed curve to recipient
+    // global guards: paused and admin enforced
     pub fn release_reserves<'info>(
         ctx: Context<'_, '_, '_, 'info, ReleaseReserves<'info>>,
     ) -> Result<()> {

--- a/programs/pump/src/states/config.rs
+++ b/programs/pump/src/states/config.rs
@@ -18,9 +18,13 @@ pub struct Config {
     pub buy_fee_percent: f64,
     pub sell_fee_percent: f64,
     pub migration_fee_percent: f64,
+
+    //  safety rails
+    pub paused: bool,
+    pub is_completed: bool,
 }
 
 impl Config {
     pub const SEED_PREFIX: &'static str = "global-config";
-    pub const LEN: usize = 32 + 32 + 8 + 8 * 4 + 8 * 3;
+    pub const LEN: usize = 32 + 32 + 8 + 8 * 4 + 8 * 3 + 1 + 1;
 }

--- a/programs/pump/src/utils/guards.rs
+++ b/programs/pump/src/utils/guards.rs
@@ -1,0 +1,18 @@
+use anchor_lang::prelude::*;
+
+use crate::{errors::PumpError, states::Config};
+
+pub fn ensure_not_paused(config: &Config) -> Result<()> {
+    require!(!config.paused, PumpError::ProgramPaused);
+    Ok(())
+}
+
+pub fn ensure_not_completed(config: &Config) -> Result<()> {
+    require!(!config.is_completed, PumpError::ProgramCompleted);
+    Ok(())
+}
+
+pub fn ensure_admin(config: &Config, admin_key: &Pubkey) -> Result<()> {
+    require_keys_eq!(config.authority, *admin_key, PumpError::NotAuthorized);
+    Ok(())
+}

--- a/programs/pump/src/utils/mod.rs
+++ b/programs/pump/src/utils/mod.rs
@@ -2,3 +2,5 @@ pub mod calc;
 pub use calc::*;
 pub mod transfer;
 pub use transfer::*;
+pub mod guards;
+pub use guards::*;

--- a/programs/pump/tests/guards.rs
+++ b/programs/pump/tests/guards.rs
@@ -1,7 +1,68 @@
 use pump::errors::PumpError;
+use pump::states::Config;
+use pump::utils::{ensure_admin, ensure_not_completed, ensure_not_paused};
+use solana_program::pubkey::Pubkey;
+
+fn dummy_config(paused: bool, completed: bool, authority: Pubkey) -> Config {
+    Config {
+        authority,
+        fee_recipient: Pubkey::new_unique(),
+        curve_limit: 0,
+        initial_virtual_token_reserves: 0,
+        initial_virtual_sol_reserves: 0,
+        initial_real_token_reserves: 0,
+        total_token_supply: 0,
+        buy_fee_percent: 0.0,
+        sell_fee_percent: 0.0,
+        migration_fee_percent: 0.0,
+        paused,
+        is_completed: completed,
+    }
+}
 
 #[tokio::test]
 async fn errors_exist() {
     let _ = PumpError::ProgramPaused;
     let _ = PumpError::ProgramCompleted;
+}
+
+#[tokio::test]
+async fn guard_not_paused_ok() {
+    let cfg = dummy_config(false, false, Pubkey::new_unique());
+    assert!(ensure_not_paused(&cfg).is_ok());
+}
+
+#[tokio::test]
+async fn guard_not_paused_err() {
+    let cfg = dummy_config(true, false, Pubkey::new_unique());
+    let err = ensure_not_paused(&cfg).unwrap_err();
+    assert_eq!(err, PumpError::ProgramPaused.into());
+}
+
+#[tokio::test]
+async fn guard_not_completed_ok() {
+    let cfg = dummy_config(false, false, Pubkey::new_unique());
+    assert!(ensure_not_completed(&cfg).is_ok());
+}
+
+#[tokio::test]
+async fn guard_not_completed_err() {
+    let cfg = dummy_config(false, true, Pubkey::new_unique());
+    let err = ensure_not_completed(&cfg).unwrap_err();
+    assert_eq!(err, PumpError::ProgramCompleted.into());
+}
+
+#[tokio::test]
+async fn guard_admin_ok() {
+    let admin = Pubkey::new_unique();
+    let cfg = dummy_config(false, false, admin);
+    assert!(ensure_admin(&cfg, &admin).is_ok());
+}
+
+#[tokio::test]
+async fn guard_admin_err() {
+    let cfg = dummy_config(false, false, Pubkey::new_unique());
+    let not_admin = Pubkey::new_unique();
+    let err = ensure_admin(&cfg, &not_admin).unwrap_err();
+    assert_eq!(err, PumpError::NotAuthorized.into());
 }

--- a/programs/pump/tests/guards.rs
+++ b/programs/pump/tests/guards.rs
@@ -1,0 +1,7 @@
+use pump::errors::PumpError;
+
+#[tokio::test]
+async fn errors_exist() {
+    let _ = PumpError::ProgramPaused;
+    let _ = PumpError::ProgramCompleted;
+}


### PR DESCRIPTION
## Enforce pause/completion guards + tests

- This PR introduces comprehensive pause, completion, and admin guards across key program instructions. The `Config` state now includes `paused` and `is_completed` flags, enforced via new utility functions (`ensure_not_paused`, `ensure_not_completed`, `ensure_admin`). This ensures that critical operations like `launch`, `swap`, `migrate`, and `release_reserves` respect the program's operational state and administrative controls, enhancing security and preventing unintended actions.

- Guard coverage table copied from `SECURITY_NOTES.md`:

| Instruction | Admin required | Blocks when paused | Blocks when is_completed |
| :---------------- | :------------- | :----------------- | :----------------------- |
| configure | Yes (except init) | No | No |
| launch | No | Yes | Yes |
| swap | No | Yes | Yes |
| migrate | Yes | Yes | Yes |
| release_reserves | Yes | Yes | No (but curve must be completed) |

### Running locally

- Requires Anchor toolchain and Solana local validator.
- Build: `anchor build`
- Test (TS): `anchor test`
- Test (Rust, optional): `cargo test -p pump`

---
<a href="https://cursor.com/background-agent?bcId=bc-18b24907-988f-4121-b11f-8fde4158316d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-18b24907-988f-4121-b11f-8fde4158316d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>