### PR TITLE
Establish repo contribution rules and checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+## Contributing
+
+- **Branch naming**: use prefixes
+  - `feat/*` for features
+  - `fix/*` for bug fixes
+  - `chore/*` for maintenance
+  - `test/*` for test-only changes
+
+- **Required checks (run locally and pass in CI)**:
+  - `anchor build`
+  - `anchor test`
+  - `pnpm -w lint` (or `npm run lint` if pnpm not installed)
+
+- **Pull Request checklist**:
+  - **IDL updated**: If program interfaces changed, run `npm run idl:refresh` and commit updated artifacts
+  - **Scripts still run**: Validate `scripts/*` commands still work (e.g., configure, launch, buy/sell)
+  - **Tests green**: `anchor test` and Node tests are passing
+
+- **Make targets**:
+  - `make check` — runs build+tests for programs and lint+tests for web
+  - `make check-programs` — `anchor build` + `anchor test`
+  - `make check-web` — lint + web tests

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PROGRAM := pump
 PROGRAM_KEYPAIR := target/deploy/$(PROGRAM)-keypair.json
 IDL_FILE := target/idl/$(PROGRAM).json
 
-.PHONY: build keys deploy program-id idl typegen devnet
+.PHONY: build keys deploy program-id idl typegen devnet test lint check check-programs check-web
 
 build:
 	anchor build
@@ -22,6 +22,32 @@ idl:
 	- anchor idl fetch $$(solana address -k $(PROGRAM_KEYPAIR)) -o $(IDL_FILE)
 	anchor typegen
 
+# Runs anchor build + anchor test for the on-chain programs
+check-programs: build test
+
+# Web checks: lint and tests (prefers pnpm workspace, falls back to npm)
+check-web: lint
+	npm test
+
+# Lint workspace (prefer pnpm -w, fallback to npm)
+lint:
+	@set -e; \
+	if command -v pnpm >/dev/null 2>&1; then \
+		echo "Running pnpm -w lint"; \
+		pnpm -w lint; \
+	else \
+		echo "pnpm not found, running npm run lint"; \
+		npm run lint; \
+	fi
+
+# Anchor tests for programs
+test:
+	anchor test
+
+# Top-level check for CI/local use
+check: check-programs check-web
+
+# Preserve existing devnet workflow
 devnet: build keys deploy program-id idl
 	@echo "Program ID: $$(solana address -k $(PROGRAM_KEYPAIR))"
 	@echo "IDL refreshed at $(IDL_FILE)"


### PR DESCRIPTION
## Enforce pause/completion guards + tests

- Brief summary of changes and rationale
  Adds `CONTRIBUTING.md` with branch naming, required checks, and PR checklist. Updates `Makefile` with `check`, `check-programs`, `check-web`, `lint`, and `test` targets to streamline developer workflow and CI.
- Guard coverage table copied from `SECURITY_NOTES.md`
  N/A (Not a security-related change)
- Instructions to run tests locally

### Running locally

- Requires Anchor toolchain and Solana local validator.
- Build: `anchor build`
- Test (TS): `anchor test`
- Test (Rust, optional): `cargo test -p pump`
- Run all checks: `make check`
- Run program checks: `make check-programs`
- Run web checks: `make check-web`

---
<a href="https://cursor.com/background-agent?bcId=bc-9a55a37e-7858-4330-9bea-0589dae59848">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a55a37e-7858-4330-9bea-0589dae59848">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

